### PR TITLE
fix(frontend): correct guest list API endpoint

### DIFF
--- a/frontend/app/admin/guests/page.tsx
+++ b/frontend/app/admin/guests/page.tsx
@@ -41,7 +41,7 @@ export default function AdminGuestsPage() {
                 setGroups(groupsData);
         
                 // Fetch guests, optionally filtering by the selected group
-                const guestUrl = new URL('/guests/admin', window.location.origin);
+                const guestUrl = new URL('/api/admin/guests', window.location.origin);
                 if (selectedGroup) {
                     guestUrl.searchParams.append('groupId', selectedGroup);
                 }


### PR DESCRIPTION
The admin dashboard was failing to display the list of guests because the frontend was making a request to an incorrect API endpoint (`/guests/admin`).

This commit corrects the URL to `/api/admin/guests`, which is the correct Next.js API route that proxies the request to the backend.