### PR TITLE
feat(admin): implement pagination for guest list

### DIFF
--- a/src/modules/guests/guests.controller.ts
+++ b/src/modules/guests/guests.controller.ts
@@ -72,11 +72,18 @@ export class GuestsController {
     }
 
     @Get('admin')
-    async findAllAdmin(@Query('groupId') groupId?: string, @Query('search') search?: string) {
+    async findAllAdmin(
+        @Query('groupId') groupId?: string,
+        @Query('search') search?: string,
+        @Query('page') page: string = '1',
+        @Query('limit') limit: string = '10',
+    ) {
         console.log('Finding all admin guests...');
-        const guests = await this.guestsService.findAllAdmin(groupId, search);
-        console.log('Guests found:', guests);
-        return guests;
+        const pageNumber = parseInt(page, 10);
+        const limitNumber = parseInt(limit, 10);
+        const result = await this.guestsService.findAllAdmin(groupId, search, pageNumber, limitNumber);
+        console.log('Guests found:', result.guests.length);
+        return result;
     }
 
     @Get('stats')


### PR DESCRIPTION
This commit adds pagination to the admin guest list to improve usability with a large number of guests.

- The backend has been updated to support paginated requests, accepting `page` and `limit` parameters.
- The `findAllAdmin` service method now uses Prisma's `skip` and `take` options to fetch paginated data and returns the total number of guests.
- The frontend has been updated with pagination controls (Previous/Next buttons and page count).
- The frontend now manages pagination state and fetches the correct page of data from the backend.