### PR TITLE
fix(guests): resolve mailer service dependency injection issue

### DIFF
--- a/src/modules/guests/guests.module.ts
+++ b/src/modules/guests/guests.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { GuestsService } from './guests.service';
 import { GuestsController } from './guests.controller';
 import { QrCodesModule } from '../qr-codes/qr-codes.module';
+import { MailerModule } from '../mailer/mailer.module';
 
 @Module({
-    imports: [QrCodesModule],
+    imports: [QrCodesModule, MailerModule],
     controllers: [GuestsController],
     providers: [GuestsService],
     exports: [GuestsService],


### PR DESCRIPTION
This commit fixes a dependency injection error where the `MailerService` was not available in the `GuestsModule`.

- Imports the `MailerModule` into the `GuestsModule` to make the `MailerService` available to the `GuestsService`.