### PR TITLE
feat(admin): add delete guest functionality

### DIFF
--- a/frontend/app/api/admin/guests/[id]/route.ts
+++ b/frontend/app/api/admin/guests/[id]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(
+    req: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    const { id } = params;
+    const baseUrl = (process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080/api').replace(/\/$/, '');
+    const backendUrl = `${baseUrl}/guests/${id}`;
+    const authHeader = req.headers.get('authorization');
+
+    try {
+        const res = await fetch(backendUrl, {
+            method: 'DELETE',
+            headers: {
+                ...(authHeader ? { Authorization: authHeader } : {}),
+            },
+        });
+
+        if (!res.ok) {
+            const errorData = await res.json();
+            return NextResponse.json({ error: errorData.message || 'Failed to delete guest' }, { status: res.status });
+        }
+
+        // Check if the response has content before trying to parse it as JSON
+        const contentLength = res.headers.get('content-length');
+        if (contentLength && parseInt(contentLength, 10) > 0) {
+            const result = await res.json();
+            return NextResponse.json(result, { status: res.status });
+        }
+
+        // If there's no content, return a 204 No Content response
+        return new NextResponse(null, { status: 204 });
+
+    } catch (error: any) {
+        return NextResponse.json({ error: error.message || 'Something went wrong' }, { status: 500 });
+    }
+}

--- a/src/modules/guests/guests.controller.ts
+++ b/src/modules/guests/guests.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, HttpException, HttpStatus, Query, Logger, Res } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, HttpException, HttpStatus, Query, Logger, Res, Delete } from '@nestjs/common';
 import { GuestsService } from './guests.service';
 import { CreateGuestDto } from './dto/create-guest.dto';
 import { Response } from 'express';
@@ -103,5 +103,10 @@ export class GuestsController {
             throw new HttpException('Guest not found', HttpStatus.NOT_FOUND);
         }
         return guest;
+    }
+
+    @Delete(':id')
+    async remove(@Param('id') id: string) {
+        return await this.guestsService.remove(id);
     }
 }

--- a/src/modules/guests/guests.service.ts
+++ b/src/modules/guests/guests.service.ts
@@ -215,4 +215,9 @@ export class GuestsService {
         return { guests, total };
     }
 
+    async remove(id: string) {
+        return await this.prisma.guest.delete({
+            where: { id },
+        });
+    }
 }


### PR DESCRIPTION
This commit adds the ability for an admin to delete a guest from the guest list in the admin dashboard.

- A `DELETE` endpoint has been added to the backend to handle the deletion of a guest by ID.
- A new Next.js API route has been created to proxy delete requests from the frontend to the backend.
- A 'Delete' button has been added to each row in the guest list table on the admin dashboard.
- A confirmation dialog is shown before deleting a guest to prevent accidental deletions.
- The guest list is automatically refreshed after a guest is deleted.