### PR TITLE
fix(build): ensure email templates are included in build output

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "assets": [
+      { "include": "**/*.html", "watchAssets": true }
+    ],
+    "watchAssets": true
+  }
+}


### PR DESCRIPTION
This commit fixes an `ENOENT: no such file or directory` error that occurred when trying to send an email because the HTML email template was not being copied to the `dist` directory during the build process.

- Creates a `nest-cli.json` file to configure the NestJS build process.
- Adds an `assets` configuration to `nest-cli.json` to ensure that all `.html` files in the `src` directory are copied to the `dist` directory during the build.