### PR TITLE
fix(app): import authmodule into the root appmodule

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { GuestGroupsModule } from './modules/guest-groups/guest-groups.module';
 import { MailerModule } from './modules/mailer/mailer.module';
 import { ThankYouModule } from './modules/thank-you/thank-you.module';
 import { ThankYouService } from './modules/thank-you/thank-you.service';
+import { AuthModule } from './modules/auth/auth.module';
 
 @Module({
     imports: [
@@ -21,6 +22,7 @@ import { ThankYouService } from './modules/thank-you/thank-you.service';
         GuestGroupsModule,
         MailerModule,
         ThankYouModule,
+        AuthModule,
     ],
 })
 export class AppModule implements OnModuleInit {


### PR DESCRIPTION
This commit fixes an 'Unknown authentication strategy "jwt"' error by importing the `AuthModule` into the root `AppModule`.

- This makes the `JwtStrategy` and other authentication providers available to the entire application, resolving the passport error.