### PR TITLE
fix(deps): add missing backend dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,12 @@
         "uuid": "^9.0.0",
         "@nestjs/passport": "^10.0.0",
         "passport": "^0.6.0",
-        "passport-jwt": "^4.0.1"
+        "passport-jwt": "^4.0.1",
+        "@nestjs/jwt": "^10.0.0",
+        "bcrypt": "^5.1.0"
     },
     "devDependencies": {
+        "@types/bcrypt": "^5.0.0",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",


### PR DESCRIPTION
This commit adds the missing dependencies `@nestjs/jwt` and `bcrypt`, and the dev dependency `@types/bcrypt` to the `package.json` file.

These packages are required for the admin authentication feature and were causing the backend to fail to start.